### PR TITLE
rename var to anytype

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4,7 +4,7 @@ fn Borrow(comptime T: type, comptime borrows: *usize) type {
     return struct {
         pointer: *const T,
 
-        pub fn read(self: *const @This(), comptime uniq: var) T {
+        pub fn read(self: *const @This(), comptime uniq: anytype) T {
             if (!alive)
                 @compileError("Borrow no longer alive!");
 
@@ -24,14 +24,14 @@ fn BorrowMut(comptime T: type, comptime borrowmuts: *usize) type {
     return struct {
         pointer: *T,
 
-        pub fn write(self: *@This(), value: T, comptime uniq: var) void {
+        pub fn write(self: *@This(), value: T, comptime uniq: anytype) void {
             if (!alive)
                 @compileError("BorrowMut no longer alive!");
 
             self.pointer.* = value;
         }
 
-        pub fn read(self: *const @This(), comptime uniq: var) T {
+        pub fn read(self: *const @This(), comptime uniq: anytype) T {
             if (!alive)
                 @compileError("BorrowMut no longer alive!");
 
@@ -49,7 +49,7 @@ fn BorrowMut(comptime T: type, comptime borrowmuts: *usize) type {
 /// Borrows are checked at compiletime. It works just like
 /// a read-write lock; There may be many borrows at a time,
 /// *or* only one mutable borrow at a time.
-pub fn RefCell(comptime T: type, comptime _: var) type {
+pub fn RefCell(comptime T: type, comptime _: anytype) type {
     comptime var borrows: usize = 0;
     comptime var mutborrows: usize = 0;
 
@@ -62,7 +62,7 @@ pub fn RefCell(comptime T: type, comptime _: var) type {
 
         /// Borrows the value. As long as a `borrow` is alive, there may not be
         /// any mutable borrow alive. Borrows can be released by calling `.release()`.
-        pub fn borrow(self: *const @This(), comptime uniq: var) Borrow(T, &borrows) {
+        pub fn borrow(self: *const @This(), comptime uniq: anytype) Borrow(T, &borrows) {
             comptime if (borrows > 0 and mutborrows > 0) {
                 @compileError("Value has already been unwrapped!");
             } else if (mutborrows > 0) {
@@ -77,7 +77,7 @@ pub fn RefCell(comptime T: type, comptime _: var) type {
         /// Borrows the value mutably. As long as `mut borrow` is alive, there may not be
         /// any other borrow or mutable borrow alive. In order words, a live mutable borrow
         /// is a unique borrow.
-        pub fn borrowMut(self: *@This(), comptime uniq: var) BorrowMut(T, &mutborrows) {
+        pub fn borrowMut(self: *@This(), comptime uniq: anytype) BorrowMut(T, &mutborrows) {
             comptime if (borrows > 0 and mutborrows > 0) {
                 @compileError("Value has already been unwrapped!");
             } else if (borrows > 0 or mutborrows > 0) {
@@ -89,7 +89,7 @@ pub fn RefCell(comptime T: type, comptime _: var) type {
             return .{ .pointer = &self.value };
         }
 
-        pub fn unwrap(self: *@This(), comptime uniq: var) T {
+        pub fn unwrap(self: *@This(), comptime uniq: anytype) T {
             comptime if (borrows > 0 and mutborrows > 0) {
                 @compileError("Value has already been unwrapped!");
             } else if (borrows > 0 or mutborrows > 0) {


### PR DESCRIPTION
updates compatibility with the current master branch of the zig compiler